### PR TITLE
Add unit tests for jobs logic

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -6,16 +6,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const dataPath = join(__dirname, '../data/jobs.sample.json')
 const { jobs: rawJobs } = JSON.parse(readFileSync(dataPath, 'utf8'))
 
-const REQUIRED = ['id', 'title', 'company', 'location', 'url', 'tags']
+export const REQUIRED = ['id', 'title', 'company', 'location', 'url', 'tags']
 
-const addLcFields = job => ({
+export const addLcFields = job => ({
   ...job,
   titleLC: job.title.toLowerCase(),
   companyLC: job.company.toLowerCase(),
   locationLC: job.location.toLowerCase()
 })
 
-export const jobs = rawJobs.filter(job => {
+export const jobIsValid = job => {
   try {
     const u = new URL(job.url)
     if (!/^https?:$/.test(u.protocol)) {
@@ -50,7 +50,9 @@ export const jobs = rawJobs.filter(job => {
   }
 
   return true
-}).map(addLcFields)
+}
+
+export const jobs = rawJobs.filter(jobIsValid).map(addLcFields)
 
 export const tags = [...new Set(jobs.flatMap(j => j.tags))].sort()
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "devDependencies": {
     "nodemon": "3.1.10",

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -1,0 +1,124 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  jobs,
+  tags,
+  filterJobs,
+  addLcFields,
+  REQUIRED,
+  jobIsValid
+} from '../lib/jobs.js'
+
+test('jobs array length', () => {
+  assert.equal(jobs.length, 10)
+})
+
+test('jobs contain lowercase helper fields', () => {
+  for (const j of jobs) {
+    assert.equal(j.titleLC, j.title.toLowerCase())
+    assert.equal(j.companyLC, j.company.toLowerCase())
+    assert.equal(j.locationLC, j.location.toLowerCase())
+  }
+})
+
+test('addLcFields augments a job correctly', () => {
+  const sample = { title: 'X', company: 'Y', location: 'Z' }
+  const result = addLcFields(sample)
+  assert.equal(result.titleLC, 'x')
+  assert.equal(result.companyLC, 'y')
+  assert.equal(result.locationLC, 'z')
+})
+
+test('REQUIRED field list is as expected', () => {
+  assert.deepEqual(REQUIRED, ['id', 'title', 'company', 'location', 'url', 'tags'])
+})
+
+test('tags are unique and sorted', () => {
+  const sorted = [...tags].sort()
+  assert.deepEqual(tags, sorted)
+  const set = new Set(tags)
+  assert.equal(set.size, tags.length)
+})
+
+test('filterJobs returns all jobs without filters', () => {
+  assert.equal(filterJobs().length, jobs.length)
+})
+
+test('filterJobs matches text case-insensitively', () => {
+  const results = filterJobs('austin')
+  assert.equal(results.length, 1)
+  assert.equal(results[0].location, 'Austin, TX')
+})
+
+test('filterJobs filters by tag', () => {
+  const results = filterJobs('', ['Remote'])
+  assert.ok(results.length > 0)
+  for (const r of results) assert.ok(r.tags.includes('Remote'))
+})
+
+test('filterJobs applies both text and tag filters', () => {
+  const results = filterJobs('engineer', ['Full-Time'])
+  assert.deepEqual(results.map(r => r.title), [
+    'Senior Front-End Engineer',
+    'DevOps Engineer',
+    'Backend Engineer - Go'
+  ])
+})
+
+test('jobIsValid accepts a well-formed job', () => {
+  const job = {
+    id: '1',
+    title: 'Engineer',
+    company: 'ACME',
+    location: 'Remote',
+    url: 'https://example.com',
+    tags: ['Remote']
+  }
+  assert.equal(jobIsValid(job), true)
+})
+
+test('jobIsValid rejects missing fields', () => {
+  const job = {
+    id: '1',
+    title: 'Engineer',
+    company: 'ACME',
+    location: 'Remote',
+    tags: ['Remote']
+  }
+  assert.equal(jobIsValid(job), false)
+})
+
+test('jobIsValid rejects malformed values', () => {
+  const job = {
+    id: '1',
+    title: 'Engineer',
+    company: 'ACME',
+    location: 'Remote',
+    url: 'https://example.com',
+    tags: 'Remote'
+  }
+  assert.equal(jobIsValid(job), false)
+})
+
+test('jobIsValid rejects unsupported protocols', () => {
+  const job = {
+    id: '1',
+    title: 'Engineer',
+    company: 'ACME',
+    location: 'Remote',
+    url: 'ftp://example.com',
+    tags: ['Remote']
+  }
+  assert.equal(jobIsValid(job), false)
+})
+
+test('jobs array is built using jobIsValid', () => {
+  const __dirnameLocal = dirname(fileURLToPath(import.meta.url))
+  const dataPath = join(__dirnameLocal, '../data/jobs.sample.json')
+  const { jobs: raw } = JSON.parse(readFileSync(dataPath, 'utf8'))
+  const expected = raw.filter(jobIsValid).map(addLcFields)
+  assert.deepEqual(jobs, expected)
+})


### PR DESCRIPTION
## Summary
- expose helper functions from `jobs.js`
- run unit tests with Node built-in runner
- add coverage for job loading, tag set, job filtering, and validation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68838c180c9c832a8eebf5231ebf3f54